### PR TITLE
feat: add network rule set support and v4 provider compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.117 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.77, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.76.0 |
 
 ## Modules
 
@@ -31,6 +31,7 @@ No modules.
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The Azure region where the Event Hub will be deployed | `string` | n/a | yes |
 | <a name="input_sku"></a> [sku](#input\_sku) | The sku for the eventhub namespace. Possible values: Basic, Standard, Premium | `string` | `"Standard"` | no |
 | <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Enable or disable public network access | `bool` | `false` | no |
+| <a name="input_network_rule_set"></a> [network\_rule\_set](#input\_network\_rule\_set) | Optional network rule set for the Event Hub Namespace.<br/>  Use this to restrict public access while still allowing trusted Azure services. | <pre>object({<br/>    default_action                 = optional(string, "Deny")<br/>    trusted_service_access_enabled = optional(bool, true)<br/>    ip_rules = optional(list(object({<br/>      ip_mask = string<br/>      action  = optional(string, "Allow")<br/>    })), [])<br/>    virtual_network_rules = optional(list(object({<br/>      subnet_id                                       = string<br/>      ignore_missing_virtual_network_service_endpoint = optional(bool, false)<br/>    })), [])<br/>  })</pre> | `null` | no |
 | <a name="input_capacity"></a> [capacity](#input\_capacity) | The capacity of the Event Hub Namespace:<br/>  - Basic: 1<br/>  - Standard: Between 1 and 20<br/>  - Premium: Between 1 and 4 | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource. | `map(string)` | `{}` | no |
 
@@ -41,8 +42,9 @@ No modules.
 | <a name="output_namespace_id"></a> [namespace\_id](#output\_namespace\_id) | The ID of the Event Hub Namespace |
 | <a name="output_namespace_name"></a> [namespace\_name](#output\_namespace\_name) | The Name of the Event Hub Namespace |
 | <a name="output_public_network_access_enabled"></a> [public\_network\_access\_enabled](#output\_public\_network\_access\_enabled) | Is Public network access enabled? |
+| <a name="output_trusted_service_access_enabled"></a> [trusted\_service\_access\_enabled](#output\_trusted\_service\_access\_enabled) | Whether trusted Azure services are allowed by the namespace network rule set |
 | <a name="output_default_primary_connection_string"></a> [default\_primary\_connection\_string](#output\_default\_primary\_connection\_string) | The primary connection string for the authorization rule RootManageSharedAccessKey |
 | <a name="output_default_primary_key"></a> [default\_primary\_key](#output\_default\_primary\_key) | The primary key for the authorization rule RootManageSharedAccessKey |
 | <a name="output_default_secondary_connection_string"></a> [default\_secondary\_connection\_string](#output\_default\_secondary\_connection\_string) | The secondary connection string for the authorization rule RootManageSharedAccessKey |
 | <a name="output_default_secondary_key"></a> [default\_secondary\_key](#output\_default\_secondary\_key) | The secondary key for the authorization rule RootManageSharedAccessKey |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,10 +1,10 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.77, < 5.0 |
 
 ## Providers
 
@@ -15,7 +15,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 2.0 |
-| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.0 |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.2 |
 | <a name="module_eventhub_namespace"></a> [eventhub\_namespace](#module\_eventhub\_namespace) | ../.. | n/a |
 
 ## Resources
@@ -37,6 +37,7 @@ No resources.
 | <a name="input_sku"></a> [sku](#input\_sku) | The sku for the eventhub namespace. Possible values: Basic, Standard, Premium | `string` | `"Standard"` | no |
 | <a name="input_capacity"></a> [capacity](#input\_capacity) | The capacity of the Event Hub Namespace:<br/>  - Basic: 1<br/>  - Standard: Between 1 and 20<br/>  - Premium: Between 1 and 4 | `number` | `1` | no |
 | <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | n/a | `bool` | `true` | no |
+| <a name="input_network_rule_set"></a> [network\_rule\_set](#input\_network\_rule\_set) | Optional network rule set for Event Hub Namespace | <pre>object({<br/>    default_action                 = optional(string, "Deny")<br/>    trusted_service_access_enabled = optional(bool, true)<br/>    ip_rules = optional(list(object({<br/>      ip_mask = string<br/>      action  = optional(string, "Allow")<br/>    })), [])<br/>    virtual_network_rules = optional(list(object({<br/>      subnet_id                                       = string<br/>      ignore_missing_virtual_network_service_endpoint = optional(bool, false)<br/>    })), [])<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -47,4 +48,4 @@ No resources.
 | <a name="output_namespace_id"></a> [namespace\_id](#output\_namespace\_id) | n/a |
 | <a name="output_public_network_access_enabled"></a> [public\_network\_access\_enabled](#output\_public\_network\_access\_enabled) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Resource group name of the managed action group instance |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,7 +29,7 @@ module "resource_names" {
 
 module "resource_group" {
   source  = "terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm"
-  version = "~> 1.0"
+  version = "~> 1.2"
 
   name     = local.resource_group_name
   location = var.region
@@ -45,6 +45,7 @@ module "eventhub_namespace" {
   sku                           = var.sku
   capacity                      = var.capacity
   public_network_access_enabled = var.public_network_access_enabled
+  network_rule_set              = var.network_rule_set
 
   tags = merge(var.tags, { resource_name = module.resource_names["eventhub_namespace"].standard })
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -136,19 +136,31 @@ variable "capacity" {
   default     = 1
 
   validation {
-    condition = (
-      (var.sku == "Basic" && var.capacity == 1) ||
-      (var.sku == "Standard" && var.capacity >= 1 && var.capacity <= 20) ||
-      (var.sku == "Premium" && var.capacity >= 1 && var.capacity <= 4)
-    )
-    error_message = "The capacity must be 1 for Basic, between 1-20 for Standard, or between 1-4 for Premium"
+    condition     = var.capacity >= 1
+    error_message = "capacity must be greater than or equal to 1."
   }
-
 }
 
 variable "public_network_access_enabled" {
   type    = bool
   default = true
+}
+
+variable "network_rule_set" {
+  description = "Optional network rule set for Event Hub Namespace"
+  type = object({
+    default_action                 = optional(string, "Deny")
+    trusted_service_access_enabled = optional(bool, true)
+    ip_rules = optional(list(object({
+      ip_mask = string
+      action  = optional(string, "Allow")
+    })), [])
+    virtual_network_rules = optional(list(object({
+      subnet_id                                       = string
+      ignore_missing_virtual_network_service_endpoint = optional(bool, false)
+    })), [])
+  })
+  default = null
 }
 
 variable "tags" {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.117"
+      version = ">= 3.77, < 5.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -19,5 +19,44 @@ resource "azurerm_eventhub_namespace" "eventhub_namespace" {
   capacity                      = var.capacity
   public_network_access_enabled = var.public_network_access_enabled
 
+  dynamic "network_rulesets" {
+    for_each = var.network_rule_set != null ? [var.network_rule_set] : []
+
+    content {
+      default_action                 = network_rulesets.value.default_action
+      public_network_access_enabled  = var.public_network_access_enabled
+      trusted_service_access_enabled = network_rulesets.value.trusted_service_access_enabled
+
+      dynamic "ip_rule" {
+        for_each = network_rulesets.value.ip_rules
+
+        content {
+          ip_mask = ip_rule.value.ip_mask
+          action  = ip_rule.value.action
+        }
+      }
+
+      dynamic "virtual_network_rule" {
+        for_each = network_rulesets.value.virtual_network_rules
+
+        content {
+          subnet_id                                       = virtual_network_rule.value.subnet_id
+          ignore_missing_virtual_network_service_endpoint = virtual_network_rule.value.ignore_missing_virtual_network_service_endpoint
+        }
+      }
+    }
+  }
+
   tags = var.tags
+
+  lifecycle {
+    precondition {
+      condition = (
+        (var.sku == "Basic" && var.capacity == 1) ||
+        (var.sku == "Standard" && var.capacity >= 1 && var.capacity <= 20) ||
+        (var.sku == "Premium" && var.capacity >= 1 && var.capacity <= 4)
+      )
+      error_message = "The capacity must be 1 for Basic, between 1-20 for Standard, or between 1-4 for Premium."
+    }
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,11 @@ output "public_network_access_enabled" {
   value       = azurerm_eventhub_namespace.eventhub_namespace.public_network_access_enabled
 }
 
+output "trusted_service_access_enabled" {
+  description = "Whether trusted Azure services are allowed by the namespace network rule set"
+  value       = try(azurerm_eventhub_namespace.eventhub_namespace.network_rulesets[0].trusted_service_access_enabled, null)
+}
+
 output "default_primary_connection_string" {
   description = "The primary connection string for the authorization rule RootManageSharedAccessKey"
   value       = azurerm_eventhub_namespace.eventhub_namespace.default_primary_connection_string

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,31 @@ variable "public_network_access_enabled" {
   default     = false
 }
 
+variable "network_rule_set" {
+  description = <<EOT
+  Optional network rule set for the Event Hub Namespace.
+  Use this to restrict public access while still allowing trusted Azure services.
+  EOT
+  type = object({
+    default_action                 = optional(string, "Deny")
+    trusted_service_access_enabled = optional(bool, true)
+    ip_rules = optional(list(object({
+      ip_mask = string
+      action  = optional(string, "Allow")
+    })), [])
+    virtual_network_rules = optional(list(object({
+      subnet_id                                       = string
+      ignore_missing_virtual_network_service_endpoint = optional(bool, false)
+    })), [])
+  })
+  default = null
+
+  validation {
+    condition     = try(var.network_rule_set == null ? true : contains(["Allow", "Deny"], var.network_rule_set.default_action), false)
+    error_message = "network_rule_set.default_action must be either Allow or Deny."
+  }
+}
+
 variable "capacity" {
   description = <<EOT
   The capacity of the Event Hub Namespace:
@@ -53,14 +78,9 @@ variable "capacity" {
   default     = 1
 
   validation {
-    condition = (
-      (var.sku == "Basic" && var.capacity == 1) ||
-      (var.sku == "Standard" && var.capacity >= 1 && var.capacity <= 20) ||
-      (var.sku == "Premium" && var.capacity >= 1 && var.capacity <= 4)
-    )
-    error_message = "The capacity must be 1 for Basic, between 1-20 for Standard, or between 1-4 for Premium"
+    condition     = var.capacity >= 1
+    error_message = "capacity must be greater than or equal to 1."
   }
-
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.117"
+      version = ">= 3.77, < 5.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds network access restriction support to the EventHub Namespace primitive module and broadens provider compatibility to support AzureRM v4.

## Changes

**Networking**
- Added `network_rule_set` input variable (optional, defaults to `null`) supporting:
  - `default_action` — `Allow` or `Deny` (default: `Deny`)
  - `trusted_service_access_enabled` — allows trusted Azure services to bypass rules (default: `true`)
  - `ip_rules` — list of allowed IP ranges
  - `virtual_network_rules` — list of allowed subnet IDs
- Network rulesets are configured via an inline `dynamic "network_rulesets"` block, replacing the removed separate `azurerm_eventhub_namespace_network_rule_set` resource (unsupported in v4)
- `public_network_access_enabled` defaults to `false`

**Provider**
- Widened AzureRM provider constraint from `~> 3.117` to `>= 3.77, < 5.0` for v4 compatibility

**Validation fix**
- Moved SKU/capacity cross-variable validation from `variable "capacity"` to a `lifecycle.precondition` on the resource — Terraform only allows a variable's validation block to reference that same variable

**Outputs**
- Added `trusted_service_access_enabled` output

## Testing

- `terraform validate` passes
- Integration test (`make go/test`) passes — apply, idempotent second apply, and destroy all succeed